### PR TITLE
Remove v4 from abi_migration_branches as it is not supported anymore

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,3 @@
 bot:
-  abi_migration_branches: [v4, v5]
+  abi_migration_branches: [v5]
 conda_forge_output_validation: true


### PR DESCRIPTION
See https://github.com/ignition-tooling/release-tools/issues/600 and https://github.com/ignitionrobotics/docs/blob/1ebf12f8f98e41b9174f158679051fb97b10070a/tools/versions.md .